### PR TITLE
Add stdIo redirection for the execute task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "compio-buf",
  "futures-util",
  "paste",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,12 @@ snafu = "0.8.6"
 hashlink = "0.10.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-compio = { version = "0.15.0", features = ["macros", "process", "dispatcher"] }
+compio = { version = "0.15.0", features = [
+    "macros",
+    "process",
+    "dispatcher",
+    "io-compat",
+] }
 futures = "0.3.31"
 futures-channel = "0.3.31"
 clap = { version = "4.5.41", features = ["derive"] }

--- a/src/tasks/execute_task.rs
+++ b/src/tasks/execute_task.rs
@@ -1,7 +1,8 @@
-use compio::process::Command;
+use compio::{io::compat::AsyncStream, process::Command, runtime::spawn};
+use futures::AsyncBufReadExt;
 use hashlink::LinkedHashMap;
 use saphyr::{Scalar, Yaml};
-use snafu::Snafu;
+use snafu::{ResultExt, Snafu};
 use std::borrow::Cow;
 use tracing::{debug, info};
 
@@ -30,31 +31,46 @@ impl TaskTrait for ExecuteTask {
     async fn run(&self) -> Result<String, TaskError> {
         info!("Running task '{}'", self.id());
 
-        let (command, args) = self.full_command();
+        let mut cmd = self.create_command();
 
-        let output = Command::new(command)
-            .args(args)
-            .output()
+        let mut handle = cmd
+            .spawn()
+            .context(SpawnSnafu {
+                command: self.command.clone(),
+                task_name: self.id(),
+            })
+            .map_err(|err| TaskError::ExecutionError { source: err })?;
+
+        // Handle stdout
+        if let Some(stdout) = handle.stdout.take() {
+            Self::spawn_stdout_handler(stdout, self.id());
+        }
+
+        // Handle stderr
+        if let Some(stderr) = handle.stderr.take() {
+            Self::spawn_stderr_handler(stderr, self.id());
+        }
+
+        let status = handle
+            .wait()
             .await
-            .map_err(|_| TaskError::ExecutionError {
-                source: ExecuteTaskError::ExecutionError {
-                    command: self.command.clone(),
-                    task_name: self.id(),
-                },
-            })?;
+            .context(WaitSnafu {
+                command: self.command.clone(),
+                task_name: self.id(),
+            })
+            .map_err(|err| TaskError::ExecutionError { source: err })?;
 
-        match output.status.success() {
-            true => {
-                info!("Task '{}' ended execution", self.id());
-                Ok(self.id())
-            }
-            false => Err(TaskError::ExecutionError {
+        if status.success() {
+            info!("Task '{}' completed successfully", self.id());
+            Ok(self.id())
+        } else {
+            Err(TaskError::ExecutionError {
                 source: ExecuteTaskError::UnsuccessfulExecution {
                     command: self.command.clone(),
                     task_name: self.id(),
-                    status: output.status.code().unwrap_or(-1),
+                    status: status.code().unwrap_or(-1),
                 },
-            }),
+            })
         }
     }
 
@@ -68,8 +84,8 @@ impl TaskTrait for ExecuteTask {
 }
 
 impl ExecuteTask {
-    // Returns the full command as a tuple of the command string and its arguments
-    // This should be os-specific
+    /// Returns the full command as a tuple of the command string and its arguments.
+    /// This should be os-specific.
     fn full_command(&self) -> (&'static str, Vec<&str>) {
         #[cfg(target_family = "windows")]
         {
@@ -82,14 +98,92 @@ impl ExecuteTask {
             ("sh", args)
         }
     }
+
+    /// Creates and configures the command with proper stdio settings
+    fn create_command(&self) -> Command {
+        let (command, args) = self.full_command();
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+        let _ = cmd.stdout(std::process::Stdio::piped());
+        let _ = cmd.stderr(std::process::Stdio::piped());
+        cmd
+    }
+
+    /// Spawns a task to handle stdout stream
+    fn spawn_stdout_handler(stdout: compio::process::ChildStdout, task_id: String) {
+        let stream = AsyncStream::new(stdout);
+        spawn(async move {
+            use futures::stream::StreamExt;
+            let reader = futures::io::BufReader::new(stream);
+            let mut lines = reader.lines();
+
+            while let Some(line_result) = lines.next().await {
+                match line_result {
+                    Ok(line) => {
+                        if !line.trim().is_empty() {
+                            info!("[{}]: {}", task_id, line.trim());
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Error reading stdout for task '{}': {}", task_id, e);
+                        break;
+                    }
+                }
+            }
+        })
+        .detach();
+    }
+
+    /// Spawns a task to handle stderr stream
+    fn spawn_stderr_handler(stderr: compio::process::ChildStderr, task_id: String) {
+        let stream = AsyncStream::new(stderr);
+        spawn(async move {
+            use futures::stream::StreamExt;
+            let reader = futures::io::BufReader::new(stream);
+            let mut lines = reader.lines();
+
+            while let Some(line_result) = lines.next().await {
+                match line_result {
+                    Ok(line) => {
+                        if !line.trim().is_empty() {
+                            info!("[{} stderr]: {}", task_id, line.trim());
+                        }
+                    }
+                    Err(e) => {
+                        debug!("Error reading stderr for task '{}': {}", task_id, e);
+                        break;
+                    }
+                }
+            }
+        })
+        .detach();
+    }
 }
 
 #[derive(Debug, Snafu)]
 pub enum ExecuteTaskError {
-    #[snafu(display("Failed to execute command '{}' for task '{}'", command, task_name))]
-    ExecutionError { command: String, task_name: String },
     #[snafu(display(
-        "Unsuccessful execution of command '{}' for task '{}'. Status: {}",
+        "Failed to spawn command '{}' for task '{}'",
+        command,
+        task_name
+    ))]
+    SpawnError {
+        command: String,
+        task_name: String,
+        source: std::io::Error,
+    },
+    #[snafu(display(
+        "Failed to wait for command '{}' for task '{}'",
+        command,
+        task_name
+    ))]
+    WaitError {
+        command: String,
+        task_name: String,
+        source: std::io::Error,
+    },
+    #[snafu(display(
+        "Command '{}' for task '{}' failed with exit code {}",
         command,
         task_name,
         status

--- a/src/tasks/execute_task.rs
+++ b/src/tasks/execute_task.rs
@@ -126,7 +126,7 @@ impl ExecuteTask {
                     }
                     Err(e) => {
                         debug!("Error reading stdout for task '{}': {}", task_id, e);
-                        break;
+                        continue;
                     }
                 }
             }
@@ -151,7 +151,7 @@ impl ExecuteTask {
                     }
                     Err(e) => {
                         debug!("Error reading stderr for task '{}': {}", task_id, e);
-                        break;
+                        continue;
                     }
                 }
             }
@@ -162,21 +162,13 @@ impl ExecuteTask {
 
 #[derive(Debug, Snafu)]
 pub enum ExecuteTaskError {
-    #[snafu(display(
-        "Failed to spawn command '{}' for task '{}'",
-        command,
-        task_name
-    ))]
+    #[snafu(display("Failed to spawn command '{}' for task '{}'", command, task_name))]
     SpawnError {
         command: String,
         task_name: String,
         source: std::io::Error,
     },
-    #[snafu(display(
-        "Failed to wait for command '{}' for task '{}'",
-        command,
-        task_name
-    ))]
+    #[snafu(display("Failed to wait for command '{}' for task '{}'", command, task_name))]
     WaitError {
         command: String,
         task_name: String,

--- a/src/tasks/execute_task.rs
+++ b/src/tasks/execute_task.rs
@@ -112,6 +112,7 @@ impl ExecuteTask {
     /// Spawns a task to handle stdout stream
     fn spawn_stdout_handler(stdout: compio::process::ChildStdout, task_id: String) {
         let stream = AsyncStream::new(stdout);
+        //TODO - return the handle to the spawned task and ensure proper shutdown
         spawn(async move {
             let reader = BufReader::new(stream);
             let mut lines = reader.lines();
@@ -135,6 +136,7 @@ impl ExecuteTask {
     /// Spawns a task to handle stderr stream
     fn spawn_stderr_handler(stderr: compio::process::ChildStderr, task_id: String) {
         let stream = AsyncStream::new(stderr);
+        //TODO - return the handle to the spawned task and ensure proper shutdown
         spawn(async move {
             let reader = BufReader::new(stream);
             let mut lines = reader.lines();


### PR DESCRIPTION
This change should add stdIo redirection to the execute task. The task's output is streamed line by line through tracing.