### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  # Enable version updates for Cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    assignees:
+      - "Miosp"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "Miosp"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
This pull request adds a new `.github/dependabot.yml` configuration file to automate dependency updates for both Cargo (Rust) packages and GitHub Actions workflows. This will help keep dependencies up to date and improve project maintainability.

Dependabot configuration:

* Added automated weekly updates for Cargo dependencies, with pull requests assigned to me, labeled appropriately, and commit messages prefixed with "cargo".
* Enabled weekly updates for GitHub Actions workflows, assigned to me, with relevant labels and commit messages prefixed with "ci".