### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,6 @@
 name: Pull Request Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Miosp/Tessy/security/code-scanning/4](https://github.com/Miosp/Tessy/security/code-scanning/4)

To fix this issue, add an explicit `permissions` key restricting all jobs to the minimum set of required permissions.  
Since all jobs in this workflow are read-only—they check formatting, run tests, check compilation, and lint code—none require more than `contents: read` (read-only access to the repository content).

The best approach is to add the following at the root of the workflow file (directly under the `name` key and before `on:`):

```yaml
permissions:
  contents: read
```

Alternatively, `permissions` blocks could be added to each job, but a single root-level block is simplest and avoids repetition.  
No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
